### PR TITLE
Updates plugin and test so they pass

### DIFF
--- a/files/default/mslicensing.rb
+++ b/files/default/mslicensing.rb
@@ -1,13 +1,13 @@
 Ohai.plugin :MSLicense do
   provides 'mslicense'
 
-  collect_data :windows do
+  collect_data :default do
     begin
       mslicense(Mash.new)
       cmd = shell_out('cscript %windir%\system32\slmgr.vbs -dlv')
       mslicense[:windowslicense] = Mash.new
       mslicense[:windowslicense][:keyManagementService] = Mash.new
-      
+
       if cmd.exitstatus == 0
         cmd.stdout.each_line() do |line|
           case line
@@ -48,7 +48,7 @@ Ohai.plugin :MSLicense do
           when /Trusted time/
             data = (line.split(':')).each(&:lstrip!)
             mslicense[:windowslicense]["trustedTime"] = ("#{data[1]}:#{data[2]}:#{data[3]}").chomp
-          
+
           # parse KMS client data
           when /Cient Machine ID/
             data = (line.split(':')).each(&:lstrip!)

--- a/spec/unit/ohai_plugins/mslicensing_spec.rb
+++ b/spec/unit/ohai_plugins/mslicensing_spec.rb
@@ -7,9 +7,10 @@ describe_ohai_plugin :MSLicense do
     expect(plugin).to provides_attribute('mslicense')
   end
 
-  stdout = 'Software licensing service version: 10.0.14393.351\r\n'
+  let(:stdout) { "Software licensing service version: 10.0.14393.351\r\n" }
+
   it 'correctly captures output' do
-    stub_plugin_shell_out('cscript %windir%\system32\slmgr.vbs -dlv', stdout)
+    allow(plugin).to receive(:shell_out).with('cscript %windir%\system32\slmgr.vbs -dlv') { double(stdout: stdout, exitstatus: 0) }
     expect(plugin_attribute('mslicense/windowslicense/serviceVersion')).to eq("10.0.14393.351")
   end
 end


### PR DESCRIPTION
The plugin file:

* Currently the chefspec-ohai plugin knows nothing about
  platforms so it will only execute the collect_data :default
  block. This is something that should change with the plugin
  to allow you to specify a platform and for that platform to
  to fake out some data with Fauxhai, etc.

The spec file:

* The `stdout` was using a string literal (single-quoted string)
  which means that characters like \r\n will be converted to \\r\\n instead of being the whitespace characters that are required.

* The help method `stub_plugin_shell_out` is a shortcut for
  `allow(plugin).to receive(:shell_out).with(command) { double(stdout: result) }`

  This is fine if all you want is the stdout but this plugin also needs to return an exit status. So I changed it to use the regular RSpec stub and gave it an exitstatus of 0. Tests could be written for when the exitstatus is not 0.

Signed-off-by: Franklin Webber <franklin@chef.io>