### PR TITLE
Adds the dependency on chefspec-ohai 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'chefspec-ohai', '0.2.0'

--- a/files/default/mslicensing.rb
+++ b/files/default/mslicensing.rb
@@ -1,7 +1,7 @@
 Ohai.plugin :MSLicense do
   provides 'mslicense'
 
-  collect_data :default do
+  collect_data :windows do
     begin
       mslicense(Mash.new)
       cmd = shell_out('cscript %windir%\system32\slmgr.vbs -dlv')

--- a/spec/unit/ohai_plugins/mslicensing_spec.rb
+++ b/spec/unit/ohai_plugins/mslicensing_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe_ohai_plugin :MSLicense do
   let(:plugin_file) { 'files/default/mslicensing.rb' }
+  let(:platform) { 'windows' }
 
   it 'provides mslicense' do
     expect(plugin).to provides_attribute('mslicense')


### PR DESCRIPTION
This version provides support for specifying the platform so
I have returned the collect_data back to :windows.

Added the gemfile as this gem is not standard with the Chef DK
so you will want others to be able to come to your cookbook and
run:

```
$ chef exec bundle install
```

Then run the tests with:

```
$ chef exec rspec
```

Signed-off-by: Franklin Webber <franklin@chef.io>